### PR TITLE
fix rye link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 `anjin` is a tool to help you understand the impact of a new release of a Python package.  It is extremely rough around the edges.  It will not guide you to the coast of feudal Japan in order to establish a trade route to compete with the Portuguese.
 
 To run:
-- [install rye](https://rye.run/docs/installation)
+- [install rye](https://rye.astral.sh/guide/installation/)
 - `rye sync`
 - `rye run anjin -r <requirements file> -c <codebase path>`
 


### PR DESCRIPTION
rye.run appears to not be a thing

<img width="1436" alt="Screenshot 2024-09-02 at 17 29 13" src="https://github.com/user-attachments/assets/90b2969a-f88e-419a-af8c-b6bacbb61d22">